### PR TITLE
Added Get and Set operations with custom Converter definitions.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,13 @@
+# rapidcsv authors
+#
+# NOTE: This list is not necessarily complete.
+#
+# Please refer to the git history for a complete list:
+#
+#   git log |grep ^Author: |sort |uniq
+#
+# Authors of commits to this repository are encouraged to
+# add their names, nicknames, email addresses, www addresses and
+# other similar information here.
+
+Pieter du Preez (https://github.com/wingunder)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ if(1)
   endif()
   add_unit_test(test061)
   add_unit_test(test062)
+  add_unit_test(test063)
 endif()
   
 # perf tests
@@ -120,4 +121,4 @@ add_executable(ex004 examples/ex004.cpp)
 add_executable(ex005 examples/ex005.cpp)
 add_executable(ex006 examples/ex006.cpp)
 add_executable(ex007 examples/ex007.cpp)
-
+add_executable(ex008 examples/ex008.cpp)

--- a/README.md
+++ b/README.md
@@ -267,6 +267,65 @@ for a complete program example.
     }
 ```
 
+Another example of a custom `Coverter` is [ex008.cpp](examples/ex008.cpp):
+
+```cpp
+#include "rapidcsv.h"
+
+namespace rapidcsv
+{
+  template<typename T>
+  class CustomConverter : public Converter<T>
+  {
+  public:
+    explicit CustomConverter(bool pHasDefaultConverter, const T& pDefaultVal)
+      : Converter<T>(pHasDefaultConverter, pDefaultVal)
+    {
+    }
+
+    void ToVal(const std::string& pStr, T& pVal) const;
+    void ToStr(const T& pVal, std::string& pStr) const;
+  };
+
+  template<>
+  void CustomConverter<int>::ToVal(const std::string& pStr, int& pVal) const
+  {
+    Converter<int>::ToVal(pStr, pVal);
+    pVal /= 4;
+  }
+
+  template<>
+  void CustomConverter<int>::ToStr(const int& pVal, std::string& pStr) const
+  {
+    const auto val = pVal * 4;
+    Converter<int>::ToStr(val, pStr);
+  }
+}
+
+int main()
+{
+  std::stringstream sstream("1,10,,1000,X\n");
+  rapidcsv::Document doc(sstream, rapidcsv::LabelParams(-1, -1));
+
+  // Create a custom converter that will force empty/invalid values
+  // to 4000. The converter will convert all inputs to integer values
+  // and then divide them by 4.
+  rapidcsv::CustomConverter<int> customConverter(true, 4000);
+
+  for (auto i = 0; i < 5; ++i)
+  {
+    std::cout << doc.GetCell<int>(i, 0, customConverter) << std::endl;
+  }
+
+  // Output:
+  // 0        // int(1 / 4) = 0
+  // 2        // int(10 / 4) = 2
+  // 1000     // int(4000 / 4) = 1000, as '' -> 4000 (default).
+  // 250      // int(1000 / 4) = 250
+  // 1000     // int(4000 / 4) = 1000, as 'X' -> 4000 (default).
+}
+```
+
 Reading CSV Data from a Stream or String
 ----------------------------------------
 In addition to specifying a filename, rapidcsv supports constructing a Document
@@ -384,7 +443,9 @@ Rapidcsv is distributed under the BSD 3-Clause license. See
 Contributions
 =============
 Bugs, PRs, etc are welcome on the GitHub project page
-https://github.com/d99kris/rapidcsv
+[https://github.com/d99kris/rapidcsv](https://github.com/d99kris/rapidcsv).
+Contributors to this repository are listed in the
+[AUTHORS](https://github.com/d99kris/rapidcsv/blob/master/AUTHORS) file.
 
 Keywords
 ========

--- a/examples/ex008.cpp
+++ b/examples/ex008.cpp
@@ -1,0 +1,61 @@
+#if 0
+TMP=$(mktemp -d)
+c++ -std=c++11 -I src -o ${TMP}/a.out ${0} && ${TMP}/a.out ${@:1} ; RV=${?}
+rm -rf ${TMP}
+exit ${RV}
+#endif
+
+#include "rapidcsv.h"
+
+namespace rapidcsv
+{
+  template<typename T>
+  class CustomConverter : public Converter<T>
+  {
+  public:
+    explicit CustomConverter(bool pHasDefaultConverter, const T& pDefaultVal)
+      : Converter<T>(pHasDefaultConverter, pDefaultVal)
+    {
+    }
+
+    void ToVal(const std::string& pStr, T& pVal) const;
+    void ToStr(const T& pVal, std::string& pStr) const;
+  };
+
+  template<>
+  void CustomConverter<int>::ToVal(const std::string& pStr, int& pVal) const
+  {
+    Converter<int>::ToVal(pStr, pVal);
+    pVal /= 4;
+  }
+
+  template<>
+  void CustomConverter<int>::ToStr(const int& pVal, std::string& pStr) const
+  {
+    const auto val = pVal * 4;
+    Converter<int>::ToStr(val, pStr);
+  }
+}
+
+int main()
+{
+  std::stringstream sstream("1,10,,1000,X\n");
+  rapidcsv::Document doc(sstream, rapidcsv::LabelParams(-1, -1));
+
+  // Create a custom converter that will force empty/invalid values
+  // to 4000. The converter will convert all inputs to integer values
+  // and then divide them by 4.
+  rapidcsv::CustomConverter<int> customConverter(true, 4000);
+
+  for (auto i = 0; i < 5; ++i)
+  {
+    std::cout << doc.GetCell<int>(i, 0, customConverter) << std::endl;
+  }
+
+  // Output:
+  // 0        // int(1 / 4) = 0
+  // 2        // int(10 / 4) = 2
+  // 1000     // int(4000 / 4) = 1000, as '' -> 4000 (default).
+  // 250      // int(1000 / 4) = 250
+  // 1000     // int(4000 / 4) = 1000, as 'X' -> 4000 (default).
+}

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -41,46 +41,6 @@ namespace rapidcsv
 #endif
 
   /**
-   * @brief     Datastructure holding parameters controlling how invalid numbers (including
-   *            empty strings) should be handled.
-   */
-  struct ConverterParams
-  {
-    /**
-     * @brief   Constructor
-     * @param   pHasDefaultConverter  specifies if conversion of non-numerical strings shall be
-     *                                converted to a default numerical value, instead of causing
-     *                                an exception to be thrown (default).
-     * @param   pDefaultFloat         floating-point default value to represent invalid numbers.
-     * @param   pDefaultInteger       integer default value to represent invalid numbers.
-     */
-    explicit ConverterParams(const bool pHasDefaultConverter = false,
-                             const long double pDefaultFloat = std::numeric_limits<long double>::signaling_NaN(),
-                             const long long pDefaultInteger = 0)
-      : mHasDefaultConverter(pHasDefaultConverter)
-      , mDefaultFloat(pDefaultFloat)
-      , mDefaultInteger(pDefaultInteger)
-    {
-    }
-
-    /**
-     * @brief   specifies if conversion of non-numerical strings shall be converted to a default
-     *          numerical value, instead of causing an exception to be thrown (default).
-     */
-    bool mHasDefaultConverter;
-
-    /**
-     * @brief   floating-point default value to represent invalid numbers.
-     */
-    long double mDefaultFloat;
-
-    /**
-     * @brief   integer default value to represent invalid numbers.
-     */
-    long long mDefaultInteger;
-  };
-
-  /**
    * @brief     Exception thrown when attempting to access Document data in a datatype which
    *            is not supported by the Converter class.
    */
@@ -107,140 +67,97 @@ namespace rapidcsv
   public:
     /**
      * @brief   Constructor
-     * @param   pConverterParams      specifies how conversion of non-numerical values to
-     *                                numerical datatype shall be handled.
+     * @param   pHasDefaultConverter  specifies if conversion of non-numerical strings shall be
+     *                                converted to a default value, instead of causing
+     *                                an exception to be thrown (default).
+     * @param   pDefaultVal           default value to represent invalid numbers.
      */
-    Converter(const ConverterParams& pConverterParams)
-      : mConverterParams(pConverterParams)
+    explicit Converter(bool pHasDefaultConverter, const T& pDefaultVal)
+      : mHasDefaultConverter(pHasDefaultConverter)
+      , mDefaultVal(pDefaultVal)
+    {
+    }
+
+    explicit Converter(bool pHasDefaultConverter)
+      : mHasDefaultConverter(pHasDefaultConverter)
+      , mDefaultVal(0)
+    {
+    }
+
+    explicit Converter()
+      : Converter(false)
     {
     }
 
     /**
      * @brief   Converts numerical value to string representation.
-     * @param   pVal                  numerical value
+     * @param   pVal                  value
      * @param   pStr                  output string
      */
-    void ToStr(const T& pVal, std::string& pStr) const
+    virtual void ToStr(const T& pVal, std::string& pStr) const
     {
-      if (typeid(T) == typeid(int) ||
-          typeid(T) == typeid(long) ||
-          typeid(T) == typeid(long long) ||
-          typeid(T) == typeid(unsigned) ||
-          typeid(T) == typeid(unsigned long) ||
-          typeid(T) == typeid(unsigned long long) ||
-          typeid(T) == typeid(float) ||
-          typeid(T) == typeid(double) ||
-          typeid(T) == typeid(long double) ||
-          typeid(T) == typeid(char))
-      {
-        std::ostringstream out;
-        out << pVal;
-        pStr = out.str();
-      }
-      else
-      {
-        throw no_converter();
-      }
+      pStr = std::to_string(pVal);
     }
 
     /**
      * @brief   Converts string holding a numerical value to numerical datatype representation.
-     * @param   pVal                  numerical value
+     * @param   pVal                  value
      * @param   pStr                  output string
      */
-    void ToVal(const std::string& pStr, T& pVal) const
+    virtual void ToVal(const std::string& pStr, T& pVal) const
     {
-      try
-      {
-        if (typeid(T) == typeid(int))
-        {
-          pVal = static_cast<T>(std::stoi(pStr));
-          return;
-        }
-        else if (typeid(T) == typeid(long))
-        {
-          pVal = static_cast<T>(std::stol(pStr));
-          return;
-        }
-        else if (typeid(T) == typeid(long long))
-        {
-          pVal = static_cast<T>(std::stoll(pStr));
-          return;
-        }
-        else if (typeid(T) == typeid(unsigned))
-        {
-          pVal = static_cast<T>(std::stoul(pStr));
-          return;
-        }
-        else if (typeid(T) == typeid(unsigned long))
-        {
-          pVal = static_cast<T>(std::stoul(pStr));
-          return;
-        }
-        else if (typeid(T) == typeid(unsigned long long))
-        {
-          pVal = static_cast<T>(std::stoull(pStr));
-          return;
-        }
-      }
-      catch (...)
-      {
-        if (!mConverterParams.mHasDefaultConverter)
-        {
-          throw;
-        }
-        else
-        {
-          pVal = static_cast<T>(mConverterParams.mDefaultInteger);
-          return;
-        }
-      }
-
-      try
-      {
-        if (typeid(T) == typeid(float))
-        {
-          pVal = static_cast<T>(std::stof(pStr));
-          return;
-        }
-        else if (typeid(T) == typeid(double))
-        {
-          pVal = static_cast<T>(std::stod(pStr));
-          return;
-        }
-        else if (typeid(T) == typeid(long double))
-        {
-          pVal = static_cast<T>(std::stold(pStr));
-          return;
-        }
-      }
-      catch (...)
-      {
-        if (!mConverterParams.mHasDefaultConverter)
-        {
-          throw;
-        }
-        else
-        {
-          pVal = static_cast<T>(mConverterParams.mDefaultFloat);
-          return;
-        }
-      }
-
-      if (typeid(T) == typeid(char))
-      {
-        pVal = static_cast<T>(pStr[0]);
-        return;
-      }
-      else
-      {
-        throw no_converter();
-      }
+      pVal = static_cast<T>(pStr[0]);
     }
 
   private:
-    const ConverterParams& mConverterParams;
+
+    void ToDefaultVal(T& pVal) const
+    {
+      if (!mHasDefaultConverter)
+      {
+        throw;
+      }
+      else
+      {
+        pVal = mDefaultVal;
+      }
+    }
+
+    /**
+     * @brief   specifies if conversion of non-numerical strings shall be converted to a default
+     *          value, instead of causing an exception to be thrown (default).
+     */
+    bool mHasDefaultConverter;
+
+    /**
+     * @brief   default value to represent invalid values.
+     */
+    T mDefaultVal;
   };
+
+  template<>
+  inline Converter<std::string>::Converter(bool pHasDefaultConverter)
+    : Converter(pHasDefaultConverter, "")
+  {
+  }
+
+  template<>
+  inline Converter<float>::Converter(bool pHasDefaultConverter)
+    : Converter(pHasDefaultConverter, std::numeric_limits<float>::signaling_NaN())
+  {
+  }
+
+  template<>
+  inline Converter<double>::Converter(bool pHasDefaultConverter)
+    : Converter(pHasDefaultConverter, std::numeric_limits<double>::signaling_NaN())
+  {
+  }
+
+  template<>
+  inline Converter<long double>::Converter(bool pHasDefaultConverter)
+    : Converter(pHasDefaultConverter, std::numeric_limits<long double>::signaling_NaN())
+  {
+  }
 
   /**
    * @brief     Specialized implementation handling string to string conversion.
@@ -253,15 +170,147 @@ namespace rapidcsv
     pStr = pVal;
   }
 
-  /**
-   * @brief     Specialized implementation handling string to string conversion.
-   * @param     pVal                  string
-   * @param     pStr                  string
-   */
+  template<>
+  inline void Converter<char>::ToStr(const char& pVal, std::string& pStr) const
+  {
+    pStr = pVal;
+  }
+
+  template<>
+  inline void Converter<double>::ToStr(const double& pVal, std::string& pStr) const
+  {
+    std::ostringstream out;
+    out << pVal;
+    pStr = out.str();
+  }
+
   template<>
   inline void Converter<std::string>::ToVal(const std::string& pStr, std::string& pVal) const
   {
     pVal = pStr;
+  }
+
+  template<>
+  inline void Converter<int>::ToVal(const std::string& pStr, int& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<int>(std::stoi(pStr));
+    }
+    catch (...)
+    {
+      Converter<int>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<long>::ToVal(const std::string& pStr, long& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<long>(std::stol(pStr));
+    }
+    catch (...)
+    {
+      Converter<long>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<long long>::ToVal(const std::string& pStr, long long& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<long long>(std::stoll(pStr));
+    }
+    catch (...)
+    {
+      Converter<long long>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<unsigned>::ToVal(const std::string& pStr, unsigned& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<unsigned>(std::stoul(pStr));
+    }
+    catch (...)
+    {
+      Converter<unsigned>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<unsigned long>::ToVal(const std::string& pStr, unsigned long& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<unsigned long>(std::stoul(pStr));
+    }
+    catch (...)
+    {
+      Converter<unsigned long>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<unsigned long long>::ToVal(const std::string& pStr, unsigned long long& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<unsigned long long>(std::stoull(pStr));
+    }
+    catch (...)
+    {
+      Converter<unsigned long long>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<float>::ToVal(const std::string& pStr, float& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<float>(std::stof(pStr));
+    }
+    catch (...)
+    {
+      Converter<float>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<double>::ToVal(const std::string& pStr, double& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<double>(std::stod(pStr));
+    }
+    catch (...)
+    {
+      Converter<double>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<long double>::ToVal(const std::string& pStr, long double& pVal) const
+  {
+    try
+    {
+      pVal = static_cast<long double>(std::stold(pStr));
+    }
+    catch (...)
+    {
+      Converter<long double>::ToDefaultVal(pVal);
+    }
+  }
+
+  template<>
+  inline void Converter<bool>::ToVal(const std::string& pStr, bool& pVal) const
+  {
+    pVal = (pStr == "true");
   }
 
   /**
@@ -304,7 +353,7 @@ namespace rapidcsv
     /**
      * @brief   Constructor
      * @param   pSeparator            specifies the column separator (default ',').
-     * @param   pTrim                 specifies whether to trim leading and trailing spaces from 
+     * @param   pTrim                 specifies whether to trim leading and trailing spaces from
      *                                cells read.
      * @param   pHasCR                specifies whether a new document (i.e. not an existing document read)
      *                                should use CR/LF instead of only LF (default is to use standard
@@ -346,17 +395,18 @@ namespace rapidcsv
      *                                data with.
      * @param   pLabelParams          specifies which row and column should be treated as labels.
      * @param   pSeparatorParams      specifies which field and row separators should be used.
-     * @param   pConverterParams      specifies how invalid numbers (including empty strings) should be
-     *                                handled.
+     * @param   pHasDefaultConverter  specifies if conversion of non-numerical strings shall be
+     *                                converted to a default value, instead of causing
+     *                                an exception to be thrown (default).
      */
     explicit Document(const std::string& pPath = std::string(),
                       const LabelParams& pLabelParams = LabelParams(),
                       const SeparatorParams& pSeparatorParams = SeparatorParams(),
-                      const ConverterParams& pConverterParams = ConverterParams())
+                      bool pHasDefaultConverter = false)
       : mPath(pPath)
       , mLabelParams(pLabelParams)
       , mSeparatorParams(pSeparatorParams)
-      , mConverterParams(pConverterParams)
+      , mHasDefaultConverter(pHasDefaultConverter)
     {
       if (!mPath.empty())
       {
@@ -375,11 +425,11 @@ namespace rapidcsv
     explicit Document(std::istream& pStream,
                       const LabelParams& pLabelParams = LabelParams(),
                       const SeparatorParams& pSeparatorParams = SeparatorParams(),
-                      const ConverterParams& pConverterParams = ConverterParams())
+                      bool pHasDefaultConverter = false)
       : mPath()
       , mLabelParams(pLabelParams)
       , mSeparatorParams(pSeparatorParams)
-      , mConverterParams(pConverterParams)
+      , mHasDefaultConverter(pHasDefaultConverter)
     {
       ReadCsv(pStream);
     }
@@ -393,7 +443,7 @@ namespace rapidcsv
       : mPath(pDocument.mPath)
       , mLabelParams(pDocument.mLabelParams)
       , mSeparatorParams(pDocument.mSeparatorParams)
-      , mConverterParams(pDocument.mConverterParams)
+      , mHasDefaultConverter(pDocument.mHasDefaultConverter)
       , mData(pDocument.mData)
       , mColumnNames(pDocument.mColumnNames)
       , mRowNames(pDocument.mRowNames)
@@ -441,21 +491,26 @@ namespace rapidcsv
      * @returns vector of column data.
      */
     template<typename T>
-    std::vector<T> GetColumn(const size_t pColumnIdx) const
+    std::vector<T> GetColumn(const size_t pColumnIdx, const Converter<T>& pConverter) const
     {
       const ssize_t columnIdx = pColumnIdx + (mLabelParams.mRowNameIdx + 1);
       std::vector<T> column;
-      Converter<T> converter(mConverterParams);
       for (auto itRow = mData.begin(); itRow != mData.end(); ++itRow)
       {
         if (std::distance(mData.begin(), itRow) > mLabelParams.mColumnNameIdx)
         {
           T val;
-          converter.ToVal(itRow->at(columnIdx), val);
+          pConverter.ToVal(itRow->at(columnIdx), val);
           column.push_back(val);
         }
       }
       return column;
+    }
+
+    template<typename T>
+    std::vector<T> GetColumn(const size_t pColumnIdx) const
+    {
+      return GetColumn<T>(pColumnIdx, Converter<T>(mHasDefaultConverter));
     }
 
     /**
@@ -464,14 +519,20 @@ namespace rapidcsv
      * @returns vector of column data.
      */
     template<typename T>
-    std::vector<T> GetColumn(const std::string& pColumnName) const
+    std::vector<T> GetColumn(const std::string& pColumnName, const Converter<T>& pConverter) const
     {
       const ssize_t columnIdx = GetColumnIdx(pColumnName);
       if (columnIdx < 0)
       {
         throw std::out_of_range("column not found: " + pColumnName);
       }
-      return GetColumn<T>(columnIdx);
+      return GetColumn<T>(columnIdx, pConverter);
+    }
+
+    template<typename T>
+    std::vector<T> GetColumn(const std::string& pColumnName) const
+    {
+      return GetColumn<T>(pColumnName, Converter<T>(mHasDefaultConverter));
     }
 
     /**
@@ -480,7 +541,7 @@ namespace rapidcsv
      * @param   pColumn               vector of column data.
      */
     template<typename T>
-    void SetColumn(const size_t pColumnIdx, const std::vector<T>& pColumn)
+    void SetColumn(const size_t pColumnIdx, const std::vector<T>& pColumn, const Converter<T>& pConverter)
     {
       const size_t columnIdx = pColumnIdx + (mLabelParams.mRowNameIdx + 1);
 
@@ -499,13 +560,18 @@ namespace rapidcsv
         }
       }
 
-      Converter<T> converter(mConverterParams);
       for (auto itRow = pColumn.begin(); itRow != pColumn.end(); ++itRow)
       {
         std::string str;
-        converter.ToStr(*itRow, str);
+        pConverter.ToStr(*itRow, str);
         mData.at(std::distance(pColumn.begin(), itRow) + (mLabelParams.mColumnNameIdx + 1)).at(columnIdx) = str;
       }
+    }
+
+    template<typename T>
+    void SetColumn(const size_t pColumnIdx, const std::vector<T>& pColumn)
+    {
+      SetColumn(pColumnIdx, pColumn, Converter<T>(mHasDefaultConverter));
     }
 
     /**
@@ -571,7 +637,7 @@ namespace rapidcsv
     {
       const ssize_t rowIdx = pRowIdx + (mLabelParams.mColumnNameIdx + 1);
       std::vector<T> row;
-      Converter<T> converter(mConverterParams);
+      Converter<T> converter(mHasDefaultConverter);
       for (auto itCol = mData.at(rowIdx).begin(); itCol != mData.at(rowIdx).end(); ++itCol)
       {
         if (std::distance(mData.at(rowIdx).begin(), itCol) > mLabelParams.mRowNameIdx)
@@ -625,7 +691,7 @@ namespace rapidcsv
         }
       }
 
-      Converter<T> converter(mConverterParams);
+      Converter<T> converter(mHasDefaultConverter);
       for (auto itCol = pRow.begin(); itCol != pRow.end(); ++itCol)
       {
         std::string str;
@@ -684,6 +750,17 @@ namespace rapidcsv
       return mData.size() - (mLabelParams.mColumnNameIdx + 1);
     }
 
+    template<typename T>
+    T GetCell(size_t pColumnIdx, size_t pRowIdx, const Converter<T>& pConverter) const
+    {
+      const ssize_t columnIdx = pColumnIdx + (mLabelParams.mRowNameIdx + 1);
+      const ssize_t rowIdx = pRowIdx + (mLabelParams.mColumnNameIdx + 1);
+
+      T val;
+      pConverter.ToVal(mData.at(rowIdx).at(columnIdx), val);
+      return val;
+    }
+
     /**
      * @brief   Get cell by index.
      * @param   pColumnIdx            zero-based column index.
@@ -691,15 +768,27 @@ namespace rapidcsv
      * @returns cell data.
      */
     template<typename T>
-    T GetCell(const size_t pColumnIdx, const size_t pRowIdx) const
+    T GetCell(size_t pColumnIdx, size_t pRowIdx) const
     {
-      const ssize_t columnIdx = pColumnIdx + (mLabelParams.mRowNameIdx + 1);
-      const ssize_t rowIdx = pRowIdx + (mLabelParams.mColumnNameIdx + 1);
+      return GetCell<T>(pColumnIdx, pRowIdx, Converter<T>(mHasDefaultConverter));
+    }
 
-      T val;
-      Converter<T> converter(mConverterParams);
-      converter.ToVal(mData.at(rowIdx).at(columnIdx), val);
-      return val;
+    template<typename T>
+    T GetCell(const std::string& pColumnName, const std::string& pRowName, const Converter<T>& pConverter) const
+    {
+      const ssize_t columnIdx = GetColumnIdx(pColumnName);
+      if (columnIdx < 0)
+      {
+        throw std::out_of_range("column not found: " + pColumnName);
+      }
+
+      const ssize_t rowIdx = GetRowIdx(pRowName);
+      if (rowIdx < 0)
+      {
+        throw std::out_of_range("row not found: " + pRowName);
+      }
+
+      return GetCell<T>(columnIdx, rowIdx, pConverter);
     }
 
     /**
@@ -711,19 +800,19 @@ namespace rapidcsv
     template<typename T>
     T GetCell(const std::string& pColumnName, const std::string& pRowName) const
     {
+      return GetCell(pColumnName, pRowName, Converter<T>(mHasDefaultConverter));
+    }
+
+    template<typename T>
+    T GetCell(const std::string& pColumnName, const size_t pRowIdx, const Converter<T>& pConverter) const
+    {
       const ssize_t columnIdx = GetColumnIdx(pColumnName);
       if (columnIdx < 0)
       {
         throw std::out_of_range("column not found: " + pColumnName);
       }
 
-      const ssize_t rowIdx = GetRowIdx(pRowName);
-      if (rowIdx < 0)
-      {
-        throw std::out_of_range("row not found: " + pRowName);
-      }
-
-      return GetCell<T>(columnIdx, rowIdx);
+      return GetCell<T>(columnIdx, pRowIdx, pConverter);
     }
 
     /**
@@ -735,13 +824,18 @@ namespace rapidcsv
     template<typename T>
     T GetCell(const std::string& pColumnName, const size_t pRowIdx) const
     {
-      const ssize_t columnIdx = GetColumnIdx(pColumnName);
-      if (columnIdx < 0)
-      {
-        throw std::out_of_range("column not found: " + pColumnName);
-      }
+      return GetCell(pColumnName, pRowIdx, Converter<T>(mHasDefaultConverter));
+    }
 
-      return GetCell<T>(columnIdx, pRowIdx);
+    template<typename T>
+    T GetCell(const size_t pColumnIdx, const std::string& pRowName, const Converter<T>& pConverter) const
+    {
+      const ssize_t rowIdx = GetRowIdx(pRowName);
+      if (rowIdx < 0)
+      {
+        throw std::out_of_range("row not found: " + pRowName);
+      }
+      return GetCell<T>(pColumnIdx, rowIdx, pConverter);
     }
 
     /**
@@ -753,13 +847,7 @@ namespace rapidcsv
     template<typename T>
     T GetCell(const size_t pColumnIdx, const std::string& pRowName) const
     {
-      const ssize_t rowIdx = GetRowIdx(pRowName);
-      if (rowIdx < 0)
-      {
-        throw std::out_of_range("row not found: " + pRowName);
-      }
-
-      return GetCell<T>(pColumnIdx, rowIdx);
+      return GetCell(pColumnIdx, pRowName, Converter<T>(mHasDefaultConverter));
     }
 
     /**
@@ -769,7 +857,7 @@ namespace rapidcsv
      * @param   pCell                 cell data.
      */
     template<typename T>
-    void SetCell(const size_t pColumnIdx, const size_t pRowIdx, const T& pCell)
+    void SetCell(const size_t pColumnIdx, const size_t pRowIdx, const T& pCell, const Converter<T>& pConverter)
     {
       const size_t columnIdx = pColumnIdx + (mLabelParams.mRowNameIdx + 1);
       const size_t rowIdx = pRowIdx + (mLabelParams.mColumnNameIdx + 1);
@@ -790,9 +878,14 @@ namespace rapidcsv
       }
 
       std::string str;
-      Converter<T> converter(mConverterParams);
-      converter.ToStr(pCell, str);
+      pConverter.ToStr(pCell, str);
       mData.at(rowIdx).at(columnIdx) = str;
+    }
+
+    template<typename T>
+    void SetCell(const size_t pColumnIdx, const size_t pRowIdx, const T& pCell)
+    {
+      SetCell(pColumnIdx, pRowIdx, pCell, Converter<T>(mHasDefaultConverter));
     }
 
     /**
@@ -802,7 +895,7 @@ namespace rapidcsv
      * @param   pCell                 cell data.
      */
     template<typename T>
-    void SetCell(const std::string& pColumnName, const std::string& pRowName, const T& pCell)
+    void SetCell(const std::string& pColumnName, const std::string& pRowName, const T& pCell, const Converter<T>& pConverter)
     {
       const ssize_t columnIdx = GetColumnIdx(pColumnName);
       if (columnIdx < 0)
@@ -816,7 +909,13 @@ namespace rapidcsv
         throw std::out_of_range("row not found: " + pRowName);
       }
 
-      SetCell<T>(columnIdx, rowIdx, pCell);
+      SetCell<T>(columnIdx, rowIdx, pCell, pConverter);
+    }
+
+    template<typename T>
+    void SetCell(const std::string& pColumnName, const std::string& pRowName, const T& pCell)
+    {
+      SetCell(pColumnName, pRowName, pCell, Converter<T>(mHasDefaultConverter));
     }
 
     /**
@@ -1218,7 +1317,7 @@ namespace rapidcsv
     std::string mPath;
     LabelParams mLabelParams;
     SeparatorParams mSeparatorParams;
-    ConverterParams mConverterParams;
+    bool mHasDefaultConverter;
     std::vector<std::vector<std::string> > mData;
     std::map<std::string, size_t> mColumnNames;
     std::map<std::string, size_t> mRowNames;

--- a/tests/test035.cpp
+++ b/tests/test035.cpp
@@ -8,17 +8,41 @@
 // Data requested as ints to be converted to fixed-point two decimal numbers
 namespace rapidcsv
 {
+  template<typename T>
+  class CustomConverter : public Converter<T>
+  {
+  public:
+    void ToVal(const std::string& pStr, T& pVal) const;
+    void ToStr(const T& pVal, std::string& pStr) const;
+  };
+
   template<>
-  void Converter<int>::ToVal(const std::string& pStr, int& pVal) const
+  void CustomConverter<int>::ToVal(const std::string& pStr, int& pVal) const
   {
     pVal = static_cast<int>(roundf(100.0f * std::stof(pStr)));
   }
 
   template<>
-  void Converter<int>::ToStr(const int& pVal, std::string& pStr) const
+  void CustomConverter<int>::ToStr(const int& pVal, std::string& pStr) const
   {
     std::ostringstream out;
     out << std::fixed << std::setprecision(2) << static_cast<float>(pVal) / 100.0f;
+    pStr = out.str();
+  }
+
+  template<>
+  void CustomConverter<std::string>::ToVal(const std::string& pStr, std::string& pVal) const
+  {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(2) << static_cast<int>(roundf(100.0f * std::stof(pStr)));
+    pVal = out.str();
+  }
+
+  template<>
+  void CustomConverter<std::string>::ToStr(const std::string& pVal, std::string& pStr) const
+  {
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(2) << static_cast<float>(std::stof(pVal)) / 100.0f;
     pStr = out.str();
   }
 }
@@ -30,29 +54,43 @@ int main()
   std::string csv =
     "1,10,100,1000\n"
     "0.1,0.01,0.001,0.006\n"
-    ;
+  ;
 
   std::string path = unittest::TempPath();
   unittest::WriteFile(path, csv);
 
   try
   {
+    rapidcsv::CustomConverter<int> intConverter;
+    rapidcsv::CustomConverter<std::string> stringConverter;
     rapidcsv::Document doc(path, rapidcsv::LabelParams(-1, -1));
 
-    unittest::ExpectEqual(int, doc.GetCell<int>(0, 0), 100);
-    unittest::ExpectEqual(int, doc.GetCell<int>(1, 0), 1000);
-    unittest::ExpectEqual(int, doc.GetCell<int>(2, 0), 10000);
-    unittest::ExpectEqual(int, doc.GetCell<int>(3, 0), 100000);
+    unittest::ExpectEqual(int, doc.GetCell<int>(0, 0, intConverter), 100);
+    unittest::ExpectEqual(int, doc.GetCell<int>(1, 0, intConverter), 1000);
+    unittest::ExpectEqual(int, doc.GetCell<int>(2, 0, intConverter), 10000);
+    unittest::ExpectEqual(int, doc.GetCell<int>(3, 0, intConverter), 100000);
 
-    unittest::ExpectEqual(int, doc.GetCell<int>(0, 1), 10);
-    unittest::ExpectEqual(int, doc.GetCell<int>(1, 1), 1);
-    unittest::ExpectEqual(int, doc.GetCell<int>(2, 1), 0);
-    unittest::ExpectEqual(int, doc.GetCell<int>(3, 1), 1);
+    unittest::ExpectEqual(int, doc.GetCell<int>(0, 1, intConverter), 10);
+    unittest::ExpectEqual(int, doc.GetCell<int>(1, 1, intConverter), 1);
+    unittest::ExpectEqual(int, doc.GetCell<int>(2, 1, intConverter), 0);
+    unittest::ExpectEqual(int, doc.GetCell<int>(3, 1, intConverter), 1);
 
-    doc.SetCell<int>(0, 0, 12345);
+    doc.SetCell<int>(0, 0, 12345, intConverter);
+
+    unittest::ExpectEqual(int, doc.GetCell<int>(0, 0, intConverter), 12345);
+    unittest::ExpectEqual(double, doc.GetCell<double>(0, 0), 123.45);
+    unittest::ExpectEqual(std::string, doc.GetCell<std::string>(0, 0, stringConverter), "12345");
+    unittest::ExpectEqual(std::string, doc.GetCell<std::string>(0, 0), "123.45");
+
+
+    doc.SetCell<std::string>(0, 0, "12345", stringConverter);
+
+    unittest::ExpectEqual(int, doc.GetCell<int>(0, 0, intConverter), 12345);
+    unittest::ExpectEqual(double, doc.GetCell<double>(0, 0), 123.45);
+    unittest::ExpectEqual(std::string, doc.GetCell<std::string>(0, 0, stringConverter), "12345");
     unittest::ExpectEqual(std::string, doc.GetCell<std::string>(0, 0), "123.45");
   }
-  catch(const std::exception& ex)
+  catch (const std::exception& ex)
   {
     std::cout << ex.what() << std::endl;
     rv = 1;
@@ -62,4 +100,3 @@ int main()
 
   return rv;
 }
-

--- a/tests/test048.cpp
+++ b/tests/test048.cpp
@@ -12,7 +12,7 @@ int main()
     "-,A,B,C\n"
     "1,,x,#\n"
     "2,,y,$\n"
-    ;
+  ;
 
   std::string path = unittest::TempPath();
   unittest::WriteFile(path, csv);
@@ -20,17 +20,17 @@ int main()
   try
   {
     rapidcsv::Document doc(path, rapidcsv::LabelParams(), rapidcsv::SeparatorParams(),
-                           rapidcsv::ConverterParams(true));
+                           true);
 
-    unittest::ExpectEqual(int, doc.GetCell<int>(0,0), 0);
-    unittest::ExpectEqual(long long, doc.GetCell<long long>(1,0), 0);
-    unittest::ExpectEqual(unsigned int, doc.GetCell<unsigned int>(2,0), 0);
+    unittest::ExpectEqual(int, doc.GetCell<int>(0, 0), 0);
+    unittest::ExpectEqual(long long, doc.GetCell<long long>(1, 0), 0);
+    unittest::ExpectEqual(unsigned int, doc.GetCell<unsigned int>(2, 0), 0);
 
-    unittest::ExpectTrue(std::isnan(doc.GetCell<double>(0,1)));
-    unittest::ExpectTrue(std::isnan(doc.GetCell<long double>(1,1)));
-    unittest::ExpectTrue(std::isnan(doc.GetCell<float>(2,1)));
+    unittest::ExpectTrue(std::isnan(doc.GetCell<double>(0, 1)));
+    unittest::ExpectTrue(std::isnan(doc.GetCell<long double>(1, 1)));
+    unittest::ExpectTrue(std::isnan(doc.GetCell<float>(2, 1)));
   }
-  catch(const std::exception& ex)
+  catch (const std::exception& ex)
   {
     std::cout << ex.what() << std::endl;
     rv = 1;
@@ -40,4 +40,3 @@ int main()
 
   return rv;
 }
-

--- a/tests/test049.cpp
+++ b/tests/test049.cpp
@@ -11,7 +11,7 @@ int main()
     "-,A,B,C\n"
     "1,,x,#\n"
     "2,,y,$\n"
-    ;
+  ;
 
   std::string path = unittest::TempPath();
   unittest::WriteFile(path, csv);
@@ -19,17 +19,25 @@ int main()
   try
   {
     rapidcsv::Document doc(path, rapidcsv::LabelParams(), rapidcsv::SeparatorParams(),
-                           rapidcsv::ConverterParams(true, 0.0, 1));
+                           true);
 
-    unittest::ExpectEqual(int, doc.GetCell<int>(0,0), 1);
-    unittest::ExpectEqual(long long, doc.GetCell<long long>(1,0), 1);
-    unittest::ExpectEqual(unsigned int, doc.GetCell<unsigned int>(2,0), 1);
+    rapidcsv::Converter<int> iConverter(true, 1);
+    rapidcsv::Converter<long long> llConverter(true, 1);
+    rapidcsv::Converter<unsigned int> uiConverter(true, 1);
 
-    unittest::ExpectEqual(double, doc.GetCell<double>(0,1), 0.0);
-    unittest::ExpectEqual(long double, doc.GetCell<long double>(1,1), 0.0);
-    unittest::ExpectEqual(float, doc.GetCell<float>(2,1), 0.0);
+    unittest::ExpectEqual(int, doc.GetCell<int>(0, 0, iConverter), 1);
+    unittest::ExpectEqual(long long, doc.GetCell<long long>(1, 0, llConverter), 1);
+    unittest::ExpectEqual(unsigned int, doc.GetCell<unsigned int>(2, 0, uiConverter), 1);
+
+    rapidcsv::Converter<double> dConverter(true, 0.0);
+    rapidcsv::Converter<long double> ldConverter(true, 0.0);
+    rapidcsv::Converter<float> fConverter(true, 0.0);
+
+    unittest::ExpectEqual(double, doc.GetCell<double>(0, 1, dConverter), 0.0);
+    unittest::ExpectEqual(long double, doc.GetCell<long double>(1, 1, ldConverter), 0.0);
+    unittest::ExpectEqual(float, doc.GetCell<float>(2, 1, fConverter), 0.0);
   }
-  catch(const std::exception& ex)
+  catch (const std::exception& ex)
   {
     std::cout << ex.what() << std::endl;
     rv = 1;
@@ -39,4 +47,3 @@ int main()
 
   return rv;
 }
-

--- a/tests/test063.cpp
+++ b/tests/test063.cpp
@@ -1,0 +1,202 @@
+// test063.cpp - custom conversions
+
+#include <rapidcsv.h>
+#include "unittest.h"
+
+class StrLenConverter : public rapidcsv::Converter<size_t>
+{
+public:
+  void ToVal(const std::string& str, size_t& val) const
+  {
+    val = str.length();
+  }
+};
+
+class ModConverter : public rapidcsv::Converter<int>
+{
+public:
+  void ToVal(const std::string& str, int& val) const
+  {
+    val = 0;
+    for (size_t i = 0; i < str.length(); ++i)
+    {
+      val += str.at(i);
+      val %= 0xFF;
+    }
+  }
+};
+
+class SexConverter : public rapidcsv::Converter<int>
+{
+public:
+  void ToStr(int val, std::string& str) const
+  {
+    if (val == 1)
+    {
+      str = "male";
+    }
+    else if (val == 2)
+    {
+      str = "female";
+    }
+    else
+    {
+      str = "";
+    }
+  }
+
+  void ToVal(const std::string& str, int& val) const
+  {
+    if (str == "male")
+    {
+      val = 1;
+    }
+    else if (str == "female")
+    {
+      val = 2;
+    }
+    else
+    {
+      val = 0;
+    }
+  }
+};
+
+class BoolConverter : public rapidcsv::Converter<bool>
+{
+public:
+  void ToStr(bool val, std::string& str) const
+  {
+    if (val)
+    {
+      str = "Yes";
+    }
+    else
+    {
+      str = "No";
+    }
+  }
+
+  void ToVal(const std::string& str, bool& val) const
+  {
+    if (str == "Yes")
+    {
+      val = true;
+    }
+    else
+    {
+      val = false;
+    }
+  }
+};
+
+int main()
+{
+  int rv = 0;
+
+  std::string csv =
+    "Id,Name,Species,Sex,Endangered,Extinct,AvgAge\n"
+    "1,Slowness,Snail,,false,No,1\n"
+    "2,Dan,Dog,male,false,No,6\n"
+    "3,Caty,Cat,female,false,No,7\n"
+    "4,Rich,Rino,male,true,No,45\n"
+    "5,Dodo,Bird,male,,Yes,\n"
+  ;
+
+  std::string path = unittest::TempPath();
+  unittest::WriteFile(path, csv);
+
+  try
+  {
+    rapidcsv::Document doc(path);
+
+    StrLenConverter strLenConverter;
+    const auto name = doc.GetColumn<size_t>("Name", strLenConverter);
+    unittest::ExpectEqual(size_t, name.at(0), 8);
+    unittest::ExpectEqual(size_t, name.at(1), 3);
+    unittest::ExpectEqual(size_t, name.at(2), 4);
+    unittest::ExpectEqual(size_t, name.at(3), 4);
+    unittest::ExpectEqual(size_t, name.at(4), 4);
+
+    ModConverter ModConverter;
+    const auto species = doc.GetColumn<int>("Species", ModConverter);
+    unittest::ExpectEqual(int, species.at(0), 248);
+    unittest::ExpectEqual(int, species.at(1), 27);
+    unittest::ExpectEqual(int, species.at(2), 25);
+    unittest::ExpectEqual(int, species.at(3), 153);
+    unittest::ExpectEqual(int, species.at(4), 130);
+
+    const auto sex = doc.GetColumn<std::string>("Sex");
+    unittest::ExpectEqual(std::string, sex.at(0), "");
+    unittest::ExpectEqual(std::string, sex.at(1), "male");
+    unittest::ExpectEqual(std::string, sex.at(2), "female");
+    unittest::ExpectEqual(std::string, sex.at(3), "male");
+    unittest::ExpectEqual(std::string, sex.at(4), "male");
+
+    SexConverter sexConverter;
+    const auto numericSex = doc.GetColumn<int>("Sex", sexConverter);
+    std::string tmp;
+    for (size_t i = 0; i < sex.size(); i++)
+    {
+      sexConverter.ToStr(numericSex.at(i), tmp);
+      unittest::ExpectEqual(std::string, sex.at(i), tmp);
+    }
+
+    const auto endangered = doc.GetColumn<bool>("Endangered");
+    unittest::ExpectEqual(bool, endangered.at(0), false);
+    unittest::ExpectEqual(bool, endangered.at(1), false);
+    unittest::ExpectEqual(bool, endangered.at(2), false);
+    unittest::ExpectEqual(bool, endangered.at(3), true);
+    unittest::ExpectEqual(bool, endangered.at(4), false);
+
+    BoolConverter boolConverter;
+    const auto extinct = doc.GetColumn<bool>("Extinct", boolConverter);
+    unittest::ExpectEqual(bool, extinct.at(0), false);
+    unittest::ExpectEqual(bool, extinct.at(1), false);
+    unittest::ExpectEqual(bool, extinct.at(2), false);
+    unittest::ExpectEqual(bool, extinct.at(3), false);
+    unittest::ExpectEqual(bool, extinct.at(4), true);
+
+    // Use the default Converter, but with the default
+    // converter parameters set.
+    // This will cause the missing avg ages to be set to 0.
+    const rapidcsv::Converter<int> avgAgeConverter(true, 0);
+    const auto avgAge = doc.GetColumn<int>("AvgAge", avgAgeConverter);
+    unittest::ExpectEqual(int32_t, avgAge.at(0), 1);
+    unittest::ExpectEqual(int32_t, avgAge.at(1), 6);
+    unittest::ExpectEqual(int32_t, avgAge.at(2), 7);
+    unittest::ExpectEqual(int32_t, avgAge.at(3), 45);
+    unittest::ExpectEqual(int32_t, avgAge.at(4), 0);
+
+    // Use the default Converter, but with the default
+    // converter parameters and values set.
+    // This will cause the missing avg ages to be set to 100.
+    const rapidcsv::Converter<int> avgAge100Converter(true, 100);
+    const auto avgAge100 = doc.GetColumn<int>("AvgAge", avgAge100Converter);
+    unittest::ExpectEqual(int32_t, avgAge100.at(0), 1);
+    unittest::ExpectEqual(int32_t, avgAge100.at(1), 6);
+    unittest::ExpectEqual(int32_t, avgAge100.at(2), 7);
+    unittest::ExpectEqual(int32_t, avgAge100.at(3), 45);
+    unittest::ExpectEqual(int32_t, avgAge100.at(4), 100);
+
+    // Use the default Converter, but with the default
+    // converter parameters and values set.
+    // This will cause the missing avg ages to be set to -1.
+    const rapidcsv::Converter<int> avgAge_1Converter(true, -1);
+    const auto avgAge_1 = doc.GetColumn<int>("AvgAge", avgAge_1Converter);
+    unittest::ExpectEqual(int32_t, avgAge_1.at(0), 1);
+    unittest::ExpectEqual(int32_t, avgAge_1.at(1), 6);
+    unittest::ExpectEqual(int32_t, avgAge_1.at(2), 7);
+    unittest::ExpectEqual(int32_t, avgAge_1.at(3), 45);
+    unittest::ExpectEqual(int32_t, avgAge_1.at(4), -1);
+  }
+  catch (const std::exception& ex)
+  {
+    std::cout << ex.what() << std::endl;
+    rv = 1;
+  }
+
+  unittest::DeleteFile(path);
+
+  return rv;
+}


### PR DESCRIPTION
The GetCell, SetCell, GetColumn and SetColumn now take an
optional (last) parameter, specifying what Converter it should
use. This is a very handy way to override the default Converter, per
cell or column. One could now convert non-homogeneous data inside a
csv.

Full examples of usage can be found in test035.cpp.

All interfaces are backwards compatible, requiring no changes to
existing code.

The use of typeid(), for routing the conversions in the Converter
class, was removed and re-implemented, using template specialization.