### PR TITLE
no more empty cell added at the end of a row

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1021,8 +1021,10 @@ namespace rapidcsv
           else if (buffer[i] == '\n')
           {
             ++lf;
-            row.push_back(mSeparatorParams.mTrim ? Trim(cell) : cell);
-            cell.clear();
+            if (!cell.empty()) {
+              row.push_back(mSeparatorParams.mTrim ? Trim(cell) : cell);
+              cell.clear();
+            }
             mData.push_back(row);
             row.clear();
             quoted = false; // disallow line breaks in quoted string, by auto-unquote at linebreak

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -303,17 +303,20 @@ namespace rapidcsv
   {
     /**
      * @brief   Constructor
-     * @param   pSeparator            specifies the column separator (default ',').
-     * @param   pTrim                 specifies whether to trim leading and trailing spaces from 
-     *                                cells read.
-     * @param   pHasCR                specifies whether a new document (i.e. not an existing document read)
-     *                                should use CR/LF instead of only LF (default is to use standard
-     *                                behavior of underlying platforms - CR/LF for Win, and LF for others).
+     * @param   pSeparator              specifies the column separator (default ',').
+     * @param   pTrim                   specifies whether to trim leading and trailing spaces from
+     *                                  cells read.
+     * @param   pDropEmptyTrailingCells specifies, whether to drop empty cells at the end of each CSV line,
+     *                                  in case the last separator is immediately followed by a line break.
+     * @param   pHasCR                  specifies whether a new document (i.e. not an existing document read)
+     *                                  should use CR/LF instead of only LF (default is to use standard
+     *                                  behavior of underlying platforms - CR/LF for Win, and LF for others).
      */
     explicit SeparatorParams(const char pSeparator = ',', const bool pTrim = false,
-                             const bool pHasCR = sPlatformHasCR)
+                             const bool pDropEmptyTrailingCells = false, const bool pHasCR = sPlatformHasCR)
       : mSeparator(pSeparator)
       , mTrim(pTrim)
+      , mDropEmptyTrailingCells(pDropEmptyTrailingCells)
       , mHasCR(pHasCR)
     {
     }
@@ -327,6 +330,12 @@ namespace rapidcsv
      * @brief   specifies whether to trim leading and trailing spaces from cells read.
      */
     bool mTrim;
+
+    /**
+     * @brief   specifies, whether to drop empty cells at the end of each CSV line,
+     *          in case the last separator is immediately followed by a line break.
+     */
+    bool mDropEmptyTrailingCells;
 
     /**
      * @brief   specifies whether new documents should use CR/LF instead of LF.
@@ -1021,7 +1030,8 @@ namespace rapidcsv
           else if (buffer[i] == '\n')
           {
             ++lf;
-            if (!cell.empty()) {
+            if (!mSeparatorParams.mDropEmptyTrailingCells ||
+                (mSeparatorParams.mDropEmptyTrailingCells && !cell.empty())) {
               row.push_back(mSeparatorParams.mTrim ? Trim(cell) : cell);
               cell.clear();
             }

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -309,14 +309,12 @@ namespace rapidcsv
      * @param   pHasCR                specifies whether a new document (i.e. not an existing document read)
      *                                should use CR/LF instead of only LF (default is to use standard
      *                                behavior of underlying platforms - CR/LF for Win, and LF for others).
-     * @param   pLBinQuotes           specifies whether to allow line breaks in quoted text.
      */
     explicit SeparatorParams(const char pSeparator = ',', const bool pTrim = false,
-                             const bool pHasCR = sPlatformHasCR, const bool pLBinQuotes = false)
+                             const bool pHasCR = sPlatformHasCR)
       : mSeparator(pSeparator)
       , mTrim(pTrim)
       , mHasCR(pHasCR)
-      , mLinebreakInQuotes(pLBinQuotes)
     {
     }
 
@@ -334,11 +332,6 @@ namespace rapidcsv
      * @brief   specifies whether new documents should use CR/LF instead of LF.
      */
     bool mHasCR;
-
-    /**
-     * @brief   specifies whether to allow line breaks in quoted text.
-     */
-    bool mLinebreakInQuotes;
   };
 
   /**
@@ -991,13 +984,9 @@ namespace rapidcsv
       std::vector<char> buffer(bufLength);
       std::vector<std::string> row;
       std::string cell;
+      bool quoted = false;
       int cr = 0;
       int lf = 0;
-      enum {
-        NOT_QUOTED,
-        SINGLE_QUOTE,
-        DOUBLE_QUOTE,
-      } quoted = NOT_QUOTED;
 
       while (fileLength > 0)
       {
@@ -1005,23 +994,11 @@ namespace rapidcsv
         pStream.read(buffer.data(), readLength);
         for (int i = 0; i < readLength; ++i)
         {
-          if (buffer[i] == '\"')
+          if (buffer[i] == '"')
           {
-            if (quoted == NOT_QUOTED && (cell.empty() || cell[0] == '\"')) {
-              quoted = DOUBLE_QUOTE;
-            }
-            else if (quoted == DOUBLE_QUOTE && cell[0] == '\"') {
-              quoted = NOT_QUOTED;
-            }
-            cell += buffer[i];
-          }
-          else if (buffer[i] == '\'')
-          {
-            if (quoted == NOT_QUOTED && (cell.empty() || cell[0] == '\'')) {
-              quoted = SINGLE_QUOTE;
-            }
-            else if (quoted == SINGLE_QUOTE && cell[0] == '\'') {
-              quoted = NOT_QUOTED;
+            if (cell.empty() || cell[0] == '"')
+            {
+              quoted = !quoted;
             }
             cell += buffer[i];
           }
@@ -1039,26 +1016,18 @@ namespace rapidcsv
           }
           else if (buffer[i] == '\r')
           {
-            if (mSeparatorParams.mLinebreakInQuotes && quoted) {
-              cell += buffer[i];
-            } else {
-              ++cr;
-            }
+            ++cr;
           }
           else if (buffer[i] == '\n')
           {
-            if (mSeparatorParams.mLinebreakInQuotes && quoted) {
-              cell += buffer[i];
-            } else {
-              ++lf;
-              if (!cell.empty()) {
-                row.push_back(mSeparatorParams.mTrim ? Trim(cell) : cell);
-                cell.clear();
-              }
-              mData.push_back(row);
-              row.clear();
-              quoted = NOT_QUOTED;
+            ++lf;
+            if (!cell.empty()) {
+              row.push_back(mSeparatorParams.mTrim ? Trim(cell) : cell);
+              cell.clear();
             }
+            mData.push_back(row);
+            row.clear();
+            quoted = false; // disallow line breaks in quoted string, by auto-unquote at linebreak
           }
           else
           {
@@ -1150,18 +1119,13 @@ namespace rapidcsv
         for (auto itc = itr->begin(); itc != itr->end(); ++itc)
         {
           if ((std::string::npos == itc->find(mSeparatorParams.mSeparator)) ||
-              ((itc->length() >= 2) && (((Trim(*itc).front() == '\"') && (Trim(*itc).back() == '\"')) ||
-                                        ((Trim(*itc).front() == '\'') && (Trim(*itc).back() == '\'')))))
+              ((itc->length() >= 2) && ((*itc)[0] == '\"') && ((*itc)[itc->length() - 1] == '\"')))
           {
             pStream << *itc;
           }
           else
           {
-            if (itc->find('\"') == std::string::npos) {
-              pStream << '\"' << *itc << '\"';
-            } else {
-              pStream << '\'' << *itc << '\'';
-            }
+            pStream << '"' << *itc << '"';
           }
 
           if (std::distance(itc, itr->end()) > 1)


### PR DESCRIPTION
When reading a CSV file, no more empty cells will be added at the end of a row. As a result, the reported column count should now be correct.