### PR TITLE
Fix rowcount on empty input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ if(1)
   add_unit_test(test062)
   add_unit_test(test063)
   add_unit_test(test064)
+  add_unit_test(test065)
 endif()
   
 # perf tests

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -769,11 +769,12 @@ namespace rapidcsv
 
     /**
      * @brief   Get number of data rows.
-     * @returns row count.
+     * @returns row count (not including the column-name header)
      */
     size_t GetRowCount() const
     {
-      return mData.size() - (mLabelParams.mColumnNameIdx + 1);
+      size_t n = mData.size();
+      return n ? n - (mLabelParams.mColumnNameIdx + 1) : 0;
     }
 
     /**

--- a/tests/test065.cpp
+++ b/tests/test065.cpp
@@ -1,0 +1,29 @@
+// test065.cpp - Row count on empty file with header
+
+#include <rapidcsv.h>
+#include "unittest.h"
+
+int main()
+{
+  int rv = 0;
+
+  std::string csv = "";
+
+  std::string path = unittest::TempPath();
+  unittest::WriteFile(path, csv);
+
+  try
+  {
+    rapidcsv::Document doc(path, rapidcsv::LabelParams(0, -1));
+    unittest::ExpectEqual(size_t, doc.GetRowCount(), 0);
+  }
+  catch (const std::exception& ex)
+  {
+    std::cout << ex.what() << std::endl;
+    rv = 1;
+  }
+
+  unittest::DeleteFile(path);
+
+  return rv;
+}


### PR DESCRIPTION
Fixes a problem where setting the column header parameter and loading an empty file
lead to high non-zero rowcounts (unsigned integer underflow).

Separate commits for unit test and actual fix.