### PR TITLE
Fix: UTF-8 BOM skipping without HAS_CODECVT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ if(1)
   add_unit_test(test063)
   add_unit_test(test064)
   add_unit_test(test065)
+  add_unit_test(test066)
 endif()
   
 # perf tests

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1165,6 +1165,22 @@ namespace rapidcsv
       int cr = 0;
       int lf = 0;
 
+      // check for UTF-8 Byte order mark and skip it when found
+      if(std::min(fileLength, bufLength) >= 3)
+      {
+        pStream.read(buffer.data(), 3);
+        if(!std::equal(buffer.begin(), buffer.begin() + 3, "\xEF\xBB\xBF"))
+        {
+          // file does not start with a UTF-8 Byte order mark
+          pStream.seekg(0, std::ios::beg);
+        }
+        else
+        {
+          // file did start with a UTF-8 Byte order mark
+          fileLength -= 3;
+        }
+      }
+
       while (fileLength > 0)
       {
         std::streamsize readLength = std::min(fileLength, bufLength);

--- a/tests/test066.cpp
+++ b/tests/test066.cpp
@@ -1,0 +1,34 @@
+// test066.cpp - test UTF-8 Byte order mark skipping without HAS_CODECVT
+
+#undef HAS_CODECVT
+#include "rapidcsv.h"
+#include "unittest.h"
+
+int main()
+{
+  int rv = 0;
+
+  std::string csvWithBom =
+    "\xef\xbb\xbfID\n"
+    "1\n"
+  ;
+
+  std::string path = unittest::TempPath();
+  unittest::WriteFile(path, csvWithBom);
+
+  try
+  {
+    rapidcsv::Document doc(path, rapidcsv::LabelParams(0, -1));
+    unittest::ExpectEqual(double, doc.GetRowCount(), 1);
+    unittest::ExpectEqual(std::string, doc.GetColumn<std::string>("ID")[0], "1");
+  }
+  catch (const std::exception& ex)
+  {
+    std::cout << ex.what() << std::endl;
+    rv = 1;
+  }
+
+  unittest::DeleteFile(path);
+
+  return rv;
+}


### PR DESCRIPTION
Necessary because some programs (like MS Excel) may put (pointless)
UTF-8 byte order marks at the beginning of files.
Having the byte order mark as part of the very first entry is very undesirable
because it is not visible in most output while breaking string matching.