### PR TITLE
Follow-up to pull request #43 - bump version, reformat code, test not to undefine HAS_CODECVT

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -2,7 +2,7 @@
  * rapidcsv.h
  *
  * URL:      https://github.com/d99kris/rapidcsv
- * Version:  6.11
+ * Version:  6.20
  *
  * Copyright (C) 2017-2020 Kristofer Berggren
  * All rights reserved.
@@ -1166,10 +1166,10 @@ namespace rapidcsv
       int lf = 0;
 
       // check for UTF-8 Byte order mark and skip it when found
-      if(std::min(fileLength, bufLength) >= 3)
+      if (std::min(fileLength, bufLength) >= 3)
       {
         pStream.read(buffer.data(), 3);
-        if(!std::equal(buffer.begin(), buffer.begin() + 3, "\xEF\xBB\xBF"))
+        if (!std::equal(buffer.begin(), buffer.begin() + 3, "\xEF\xBB\xBF"))
         {
           // file does not start with a UTF-8 Byte order mark
           pStream.seekg(0, std::ios::beg);

--- a/tests/test066.cpp
+++ b/tests/test066.cpp
@@ -1,6 +1,5 @@
-// test066.cpp - test UTF-8 Byte order mark skipping without HAS_CODECVT
+// test066.cpp - test UTF-8 Byte order mark skipping
 
-#undef HAS_CODECVT
 #include "rapidcsv.h"
 #include "unittest.h"
 
@@ -19,7 +18,7 @@ int main()
   try
   {
     rapidcsv::Document doc(path, rapidcsv::LabelParams(0, -1));
-    unittest::ExpectEqual(double, doc.GetRowCount(), 1);
+    unittest::ExpectEqual(size_t, doc.GetRowCount(), 1);
     unittest::ExpectEqual(std::string, doc.GetColumn<std::string>("ID")[0], "1");
   }
   catch (const std::exception& ex)


### PR DESCRIPTION
This PR is a follow-up to #43 bumping lib version, reformating code using uncrustify, undefining HAS_CODECVT in test case.