### PR TITLE
SetColumnName/SetRowName to support extending document adding new columns/rows

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1129,6 +1129,17 @@ namespace rapidcsv
         throw std::out_of_range("row name column index < 0: " + std::to_string(mLabelParams.mRowNameIdx));
       }
 
+      // increase table size if necessary:
+      if (rowIdx >= (int)mData.size())
+      {
+        mData.resize(rowIdx + 1);
+      }
+      auto& row = mData[rowIdx];
+      if (mLabelParams.mRowNameIdx >= (int)row.size())
+      {
+        row.resize(mLabelParams.mRowNameIdx + 1);
+      }
+
       mData.at(rowIdx).at(mLabelParams.mRowNameIdx) = pRowName;
     }
 

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1068,6 +1068,12 @@ namespace rapidcsv
         throw std::out_of_range("column name row index < 0: " + std::to_string(mLabelParams.mColumnNameIdx));
       }
 
+      // increase table size if necessary:
+      int rowIdx = mLabelParams.mColumnNameIdx;
+      if ((int)mData.size() <= rowIdx) mData.resize(rowIdx + 1);
+      auto& row = mData[rowIdx];
+      if ((int)row.size() <= columnIdx) row.resize(columnIdx + 1);
+
       mData.at(mLabelParams.mColumnNameIdx).at(columnIdx) = pColumnName;
     }
 

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1069,10 +1069,16 @@ namespace rapidcsv
       }
 
       // increase table size if necessary:
-      int rowIdx = mLabelParams.mColumnNameIdx;
-      if ((int)mData.size() <= rowIdx) mData.resize(rowIdx + 1);
+      const int rowIdx = mLabelParams.mColumnNameIdx;
+      if (rowIdx >= (int)mData.size())
+      {
+        mData.resize(rowIdx + 1);
+      }
       auto& row = mData[rowIdx];
-      if ((int)row.size() <= columnIdx) row.resize(columnIdx + 1);
+      if (columnIdx >= (int)row.size())
+      {
+        row.resize(columnIdx + 1);
+      }
 
       mData.at(mLabelParams.mColumnNameIdx).at(columnIdx) = pColumnName;
     }


### PR DESCRIPTION
SetColumnName: allow setting column names for an empty table / empty column

Hi @d99kris 
Thank you for rapidcsv! I love the easy-to-use interface.

My use-case creates a table (no CSV import), then exports to CSV. I need to prepare the table and set the column names _before_ adding any data. This PR avoids the crash.
Tested on Windows with Visual Studio 2017.

Note: I did not change the version number in line 5.

Note2: Maybe need a similar fix for SetRowName?