### PR TITLE
use std::filesystem::path for all file paths, to be platform independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -Wpedantic -Wshadow -Wpointer-arith \
                        -Wcast-qual -Wno-missing-braces -Wswitch-default -Wcast-align -Wunreachable-code \
                        -Wundef -Wuninitialized")
+  link_libraries(stdc++fs)
 endif()
 
 include(CheckIncludeFileCXX)

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <typeinfo>
 #include <vector>
+#include <filesystem>
 
 #if defined(_MSC_VER)
 #include <BaseTsd.h>
@@ -369,7 +370,7 @@ namespace rapidcsv
      * @param   pConverterParams      specifies how invalid numbers (including empty strings) should be
      *                                handled.
      */
-    explicit Document(const std::string& pPath = std::string(),
+    explicit Document(const std::filesystem::path& pPath = std::filesystem::path(),
                       const LabelParams& pLabelParams = LabelParams(),
                       const SeparatorParams& pSeparatorParams = SeparatorParams(),
                       const ConverterParams& pConverterParams = ConverterParams())
@@ -425,7 +426,7 @@ namespace rapidcsv
      * @param   pPath                 specifies the path of an existing CSV-file to populate the Document
      *                                data with.
      */
-    void Load(const std::string& pPath)
+    void Load(const std::filesystem::path& pPath)
     {
       mPath = pPath;
       ReadCsv();
@@ -437,7 +438,7 @@ namespace rapidcsv
      *                                (if not specified, the original path provided when creating or
      *                                loading the Document data will be used).
      */
-    void Save(const std::string& pPath = std::string())
+    void Save(const std::filesystem::path& pPath = std::filesystem::path())
     {
       if (!pPath.empty())
       {
@@ -1507,7 +1508,7 @@ namespace rapidcsv
     }
 
   private:
-    std::string mPath;
+    std::filesystem::path mPath;
     LabelParams mLabelParams;
     SeparatorParams mSeparatorParams;
     ConverterParams mConverterParams;

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -27,7 +27,14 @@
 #include <string>
 #include <typeinfo>
 #include <vector>
-#include <filesystem>
+
+#ifdef __cpp_lib_filesystem
+  #include <filesystem>
+  namespace fs = std::filesystem;
+#else
+  #include <experimental/filesystem>
+  namespace fs = std::experimental::filesystem;
+#endif
 
 #if defined(_MSC_VER)
 #include <BaseTsd.h>
@@ -370,7 +377,7 @@ namespace rapidcsv
      * @param   pConverterParams      specifies how invalid numbers (including empty strings) should be
      *                                handled.
      */
-    explicit Document(const std::filesystem::path& pPath = std::filesystem::path(),
+    explicit Document(const fs::path& pPath = fs::path(),
                       const LabelParams& pLabelParams = LabelParams(),
                       const SeparatorParams& pSeparatorParams = SeparatorParams(),
                       const ConverterParams& pConverterParams = ConverterParams())
@@ -426,7 +433,7 @@ namespace rapidcsv
      * @param   pPath                 specifies the path of an existing CSV-file to populate the Document
      *                                data with.
      */
-    void Load(const std::filesystem::path& pPath)
+    void Load(const fs::path& pPath)
     {
       mPath = pPath;
       ReadCsv();
@@ -438,7 +445,7 @@ namespace rapidcsv
      *                                (if not specified, the original path provided when creating or
      *                                loading the Document data will be used).
      */
-    void Save(const std::filesystem::path& pPath = std::filesystem::path())
+    void Save(const fs::path& pPath = fs::path())
     {
       if (!pPath.empty())
       {
@@ -1508,7 +1515,7 @@ namespace rapidcsv
     }
 
   private:
-    std::filesystem::path mPath;
+    fs::path mPath;
     LabelParams mLabelParams;
     SeparatorParams mSeparatorParams;
     ConverterParams mConverterParams;


### PR DESCRIPTION
Hi @d99kris ,

On Windows, non-ascii file paths are expressed with std::wstring. Apparently std::filesystem::path is the platform independent solution; internally it uses wstring on Windows and string (utf-8) on POSIX.

My changes work fine on Windows, but unfortunately, I cannot easily run a test on a POSIX system. 

Please consider my PR, I hope it is useful. Please check if it does not break anything or has any other disadvantage on Linux etc.

Please let me know what you think.

Thank you
Sven