### PR TITLE
add Load(istream&) function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ add_unit_test(test072)
 add_unit_test(test073)
 add_unit_test(test074)
 add_unit_test(test075)
+add_unit_test(test076)
   
 # perf tests
 add_perf_test(ptest001)

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -432,6 +432,16 @@ namespace rapidcsv
     }
 
     /**
+     * @brief   Read Document data from stream.
+     * @param   pStream               specifies an input stream to read CSV data from.
+     */
+    void Load(std::istream& pStream)
+    {
+      mPath = "";
+      ReadCsv(pStream);
+    }
+
+    /**
      * @brief   Write Document data to file.
      * @param   pPath                 optionally specifies the path where the CSV-file will be created
      *                                (if not specified, the original path provided when creating or

--- a/tests/test076.cpp
+++ b/tests/test076.cpp
@@ -1,0 +1,59 @@
+// test076.cpp - Load from stream
+
+#include <rapidcsv.h>
+#include "unittest.h"
+
+int main()
+{
+  int rv = 0;
+
+  std::string csv =
+    "-,A,B,C\n"
+    "1,3,9,81\n"
+    "2,4,16,256\n"
+  ;
+
+  std::string path = unittest::TempPath();
+  unittest::WriteFile(path, csv);
+
+  try
+  {
+    // stream from file
+    std::ifstream fstream;
+    fstream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+    fstream.open(path, std::ios::binary | std::ios::ate);
+    rapidcsv::Document doc1("", rapidcsv::LabelParams(0, 0));
+    doc1.Load(fstream);
+    fstream.close();
+
+    unittest::ExpectEqual(int, doc1.GetCell<int>(0, 0), 3);
+    unittest::ExpectEqual(int, doc1.GetCell<int>(1, 0), 9);
+    unittest::ExpectEqual(int, doc1.GetCell<int>(2, 0), 81);
+
+    unittest::ExpectEqual(std::string, doc1.GetCell<std::string>("A", "2"), "4");
+    unittest::ExpectEqual(std::string, doc1.GetCell<std::string>("B", "2"), "16");
+    unittest::ExpectEqual(std::string, doc1.GetCell<std::string>("C", "2"), "256");
+
+    // stream from string
+    std::istringstream sstream(csv);
+    rapidcsv::Document doc2("", rapidcsv::LabelParams(0, 0));
+    doc2.Load(sstream);
+
+    unittest::ExpectEqual(int, doc2.GetCell<int>(0, 0), 3);
+    unittest::ExpectEqual(int, doc2.GetCell<int>(1, 0), 9);
+    unittest::ExpectEqual(int, doc2.GetCell<int>(2, 0), 81);
+
+    unittest::ExpectEqual(std::string, doc2.GetCell<std::string>("A", "2"), "4");
+    unittest::ExpectEqual(std::string, doc2.GetCell<std::string>("B", "2"), "16");
+    unittest::ExpectEqual(std::string, doc2.GetCell<std::string>("C", "2"), "256");
+  }
+  catch (const std::exception& ex)
+  {
+    std::cout << ex.what() << std::endl;
+    rv = 1;
+  }
+
+  unittest::DeleteFile(path);
+
+  return rv;
+}


### PR DESCRIPTION
analog to stream options in Constructor and in Save.

This allows to read from wstring file paths under windows, making https://github.com/d99kris/rapidcsv/pull/58 unnecessary.

@d99kris Please review. Thanks!