### PR TITLE
Missing cpp header

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <string>
@@ -715,7 +716,8 @@ namespace rapidcsv
       {
         std::string str;
         converter.ToStr(*itRow, str);
-        mData.at(static_cast<size_t>(std::distance(pColumn.begin(), itRow) + mLabelParams.mColumnNameIdx + 1)).at(dataColumnIdx) = str;
+        mData.at(static_cast<size_t>(std::distance(pColumn.begin(), itRow) + mLabelParams.mColumnNameIdx + 1)).at(
+          dataColumnIdx) = str;
       }
     }
 
@@ -790,7 +792,8 @@ namespace rapidcsv
         {
           std::string str;
           converter.ToStr(*itRow, str);
-          const size_t rowIdx = static_cast<size_t>(std::distance(pColumn.begin(), itRow) + (mLabelParams.mColumnNameIdx + 1));
+          const size_t rowIdx =
+            static_cast<size_t>(std::distance(pColumn.begin(), itRow) + (mLabelParams.mColumnNameIdx + 1));
           column.at(rowIdx) = str;
         }
       }
@@ -956,7 +959,8 @@ namespace rapidcsv
       {
         std::string str;
         converter.ToStr(*itCol, str);
-        mData.at(dataRowIdx).at(static_cast<size_t>(std::distance(pRow.begin(), itCol) + mLabelParams.mRowNameIdx + 1)) = str;
+        mData.at(dataRowIdx).at(static_cast<size_t>(std::distance(pRow.begin(),
+                                                                  itCol) + mLabelParams.mRowNameIdx + 1)) = str;
       }
     }
 


### PR DESCRIPTION
## Problem

With recent gcc version (such as gcc v11.2.0), the following error occurs when compiling a program which include rapidcsv.h.

```bash
In file included from /home/nusget/develop/rapidcsv/tests/test001.cpp:3:
/home/nusget/develop/rapidcsv/src/rapidcsv.h:62:69: error: ‘numeric_limits’ is not a member of ‘std’
   62 |                              const long double pDefaultFloat = std::numeric_limits<long double>::signaling_NaN(),

```

## Solution

Add the missing <limits> header where `std::numeric_limits` is defined.

Changes at lines 718, 793 and 959 arise from the code formatting tool: `uncrustify -c uncrustify.cfg --no-backup src/rapidcsv.h`


#### Tested on Linux, gcc v11.2.0

That's my two cents to your easy-to-use CSV parser 🥇