### PR TITLE
Fix/no converter override

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -98,11 +98,12 @@ namespace rapidcsv
    */
   class no_converter : public std::exception
   {
+  public:
     /**
      * @brief   Provides details about the exception
      * @returns an explanatory string
      */
-    virtual const char* what() const throw()
+    const char* what() const throw() override
     {
       return "unsupported conversion datatype";
     }

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -2,9 +2,9 @@
  * rapidcsv.h
  *
  * URL:      https://github.com/d99kris/rapidcsv
- * Version:  8.70
+ * Version:  8.71
  *
- * Copyright (C) 2017-2022 Kristofer Berggren
+ * Copyright (C) 2017-2023 Kristofer Berggren
  * All rights reserved.
  *
  * rapidcsv is distributed under the BSD 3-Clause license, see LICENSE for details.

--- a/tests/test063.cpp
+++ b/tests/test063.cpp
@@ -61,6 +61,11 @@ int main()
 
     unittest::ExpectEqual(int, doc.GetColumn<Struct>(0, ToStruct).at(0).val, 100);
     unittest::ExpectEqual(int, doc.GetColumn<Struct>("B", ToStruct).at(0).val, 1000);
+
+    // Missing custom conversion function
+    ExpectException(doc.GetColumn<bool>(0).at(0), rapidcsv::no_converter);
+    ExpectExceptionMsg(doc.GetColumn<bool>(0).at(0), rapidcsv::no_converter,
+                       "unsupported conversion datatype");
   }
   catch (const std::exception& ex)
   {


### PR DESCRIPTION
## Problem

The `rapidcsv::no_converter::what()` method was private and thus could not be used. Actually, this method did not override the `std::exception::what()` public method.

The `rapidcsv::no_converter::what()` method, which was declared `virtual`, creates a new virtual function that could be overridden in the derived classes of `rapidcsv::no_converter` itself. Instead we would like the method to override the `std::exception` one.

## Solution

* Make `rapidcsv::no_converter::what()` method `public`;
* Use override keyword to make sure it actually override the method from base class.

**Bonus:** I have updated the copyright 😃 

Thanks again for the CSV parser 🥇 