### PR TITLE
Fix build error with GCC 4.8.5

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -148,13 +148,13 @@ namespace rapidcsv
       else if (typeid(T) == typeid(float))
       {
         std::ostringstream out;
-        out << std::defaultfloat << std::setprecision(9) << pVal;
+        out << std::setprecision(9) << pVal;
         pStr = out.str();
       }
       else if (typeid(T) == typeid(double))
       {
         std::ostringstream out;
-        out << std::defaultfloat << std::setprecision(17) << pVal;
+        out << std::setprecision(17) << pVal;
         pStr = out.str();
       }
       else

--- a/tests/test092.cpp
+++ b/tests/test092.cpp
@@ -11,7 +11,7 @@ int main()
   std::string loc = "de_DE"; // uses comma (,) as decimal separator
   try
   {
-    std::locale::global(std::locale(loc));
+    std::locale::global(std::locale(loc.c_str()));
   }
   catch (const std::exception& ex)
   {


### PR DESCRIPTION
A build error is encountered when using the library with GCC 4.8.5 (old compiler, I know, sorry... ;-) ). The error is:

```
$ ./make.sh build
...
In file included from /data_local/l0440448/rapidcsv/tests/test010.cpp:3:0:
/data_local/l0440448/rapidcsv/src/rapidcsv.h: In member function ‘void rapidcsv::Converter<T>::ToStr(const T&, std::string&) const’:
/data_local/l0440448/rapidcsv/src/rapidcsv.h:151:16: error: 
‘defaultfloat’ is not a member of ‘std’
         out << std::defaultfloat << std::setprecision(9) << pVal;
                ^
```
[(full log)](https://github.com/d99kris/rapidcsv/files/12015992/make-build-gcc-4.8.5.error-1.txt)

Although GCC 4.8.5 is a rather old compiler, it is (or at least it claims to be) [C++11 compatible](https://gcc.gnu.org/projects/cxx-status.html#cxx11). It is also used in some distributions that have a slow package update policy (Red Hat EL 7.9 in the context in which I facing this bug). I'm proposing this fix to make rapidcsv back-compatible with GCC 4.8.5.
