### PR TITLE
Correct default arguments for SeparatorParams constructor in docs

### DIFF
--- a/doc/rapidcsv_SeparatorParams.md
+++ b/doc/rapidcsv_SeparatorParams.md
@@ -5,7 +5,7 @@ Datastructure holding parameters controlling how the CSV data fields are separat
 ---
 
 ```c++
-SeparatorParams (const char pSeparator = ',', const bool pTrim = false, const bool pHasCR = sPlatformHasCR, const bool pQuotedLinebreaks = false, const bool pAutoQuote = true, const char pQuoteChar = ''')
+SeparatorParams (const char pSeparator = ',', const bool pTrim = false, const bool pHasCR = sPlatformHasCR, const bool pQuotedLinebreaks = false, const bool pAutoQuote = true, const char pQuoteChar = '"')
 ```
 Constructor. 
 


### PR DESCRIPTION
The docs listed `'''` as the default value for `pQuotedChar` in the codeblock, but `'"'` under the **Parameters** section. The codeblock was wrong, and has now been corrected.