### PR TITLE
ClusterFuzzLite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/rapidcsv
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/rapidcsv

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,4 @@
+# ClusterFuzzLite set up
+
+This folder holds logic for fuzzing by way of [ClusterfuzzLite](https://google.github.io/clusterfuzzlite).
+    

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,5 @@
+# Copy all fuzzer executables to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/rapidcsv/.clusterfuzzlite/fuzz_parser.cpp \
+  -o $OUT/fuzz_parser \
+  -I$SRC/rapidcsv/src

--- a/.clusterfuzzlite/fuzz_parser.cpp
+++ b/.clusterfuzzlite/fuzz_parser.cpp
@@ -1,0 +1,18 @@
+#include <fstream>
+#include <rapidcsv.h>
+#include <string>
+
+using namespace std;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  std::string fuzz_payload(reinterpret_cast<const char *>(data), size);
+
+  ofstream myfile;
+  myfile.open("/tmp/fuzz.csv");
+  myfile << fuzz_payload;
+  myfile.close();
+
+  rapidcsv::Document doc("/tmp/fuzz.csv");
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets the parsing logic, and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.