### PR TITLE
fix for trimmed quoted separators

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1584,9 +1584,18 @@ namespace rapidcsv
         {
           if (buffer[i] == mSeparatorParams.mQuoteChar)
           {
-            if (cell.empty() || (cell[0] == mSeparatorParams.mQuoteChar))
+           if (cell.empty() || (cell[0] == mSeparatorParams.mQuoteChar))
             {
               quoted = !quoted;
+            }
+            else if(mSeparatorParams.mTrim)
+            {
+              // allow whitespace before first mQuoteChar
+              const auto firstQuote = std::find(cell.begin(), cell.end(), mSeparatorParams.mQuoteChar);
+              if(std::all_of(cell.begin(), firstQuote, [](int ch) { return isspace(ch); }))
+              {
+                quoted = !quoted;
+              }
             }
             cell += buffer[i];
           }


### PR DESCRIPTION
This is a fix for the following issue:
Sample document:
```
first, second
"yes", ", but"
```

Note the space after the separator. When loading this file (with `pTrim = true` and `pAutoQuote = true`), the second column will be read as only `"\""`, the comma after it will be interpreted as another separator.

The cause is in rapidcsv.h:1587:
```cpp
if (cell.empty() || (cell[0] == mSeparatorParams.mQuoteChar))
{
    quoted = !quoted;
}
```
which does not trigger when there is whitespace before the opening quote.

This PR allows for whitespace in front of the first quote when trimming is enabled.