### PR TITLE
generate and install a cmake configuration file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Project
 cmake_minimum_required(VERSION 3.14...3.22 FATAL_ERROR)
 project(rapidcsv VERSION 1.0 LANGUAGES CXX)
+include(CMakePackageConfigHelpers)
 set (CMAKE_CXX_STANDARD 11)
 if(MSVC)
   if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
@@ -30,7 +31,10 @@ endif()
 
 # Library
 add_library(rapidcsv INTERFACE)
-target_include_directories(rapidcsv INTERFACE src)
+target_include_directories(rapidcsv INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  $<INSTALL_INTERFACE:include>
+)
 
 # Tests
 option(RAPIDCSV_BUILD_TESTS "Build tests" OFF)
@@ -219,8 +223,22 @@ endif()
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
   message(STATUS "Install/uninstall targets enabled.")
 
-  # Install
+  # Install header
   install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/rapidcsv.h DESTINATION include)
+
+  # Export targets
+  install(TARGETS rapidcsv EXPORT rapidcsvTargets)
+  install(EXPORT rapidcsvTargets
+          NAMESPACE rapidcsv::
+          DESTINATION cmake)
+
+  # Generate and install config files
+  configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/rapidcsvConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/rapidcsvConfig.cmake
+    INSTALL_DESTINATION cmake
+  )
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rapidcsvConfig.cmake DESTINATION cmake)
 
   # Uninstall
   add_custom_target(uninstall COMMAND "${CMAKE_COMMAND}" -E remove "${CMAKE_INSTALL_PREFIX}/include/rapidcsv.h"

--- a/cmake/rapidcsvConfig.cmake.in
+++ b/cmake/rapidcsvConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/rapidcsvTargets.cmake")


### PR DESCRIPTION
This change enables downstream cmake projects to automatically discover and consume repidcsv via `find_package`
Downstream projects can simply link against the imported target
```
target_link_libraries(my_target PRIVATE rapidcsv::rapidcsv)
```

This change is made as a follow-up to [Discussion #125](https://github.com/d99kris/rapidcsv/discussions/125).