### PR TITLE
fixes auto-quote not quoting cells containing quote characters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if(RAPIDCSV_BUILD_TESTS)
   endif()
   add_unit_test(test102)
   add_unit_test(test103)
+  add_unit_test(test104)
 
   # perf tests
   add_perf_test(ptest001)

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1820,6 +1820,7 @@ namespace rapidcsv
         {
           if (mSeparatorParams.mAutoQuote &&
               ((itc->find(mSeparatorParams.mSeparator) != std::string::npos) ||
+               (itc->find(mSeparatorParams.mQuoteChar) != std::string::npos) ||
                (itc->find(' ') != std::string::npos) ||
                (itc->find('\n') != std::string::npos)))
           {

--- a/tests/test104.cpp
+++ b/tests/test104.cpp
@@ -1,0 +1,81 @@
+// test104.cpp - write round-trip with cells containing quote characters
+
+#include <rapidcsv.h>
+#include "unittest.h"
+
+int main()
+{
+  int rv = 0;
+
+  try
+  {
+    // Test 1: Cell containing quote character but no separator/space/newline
+    {
+      std::string path = unittest::TempPath();
+      std::string csv =
+        "a,b,c\n"
+        "1,he said \"hello\",3\n"
+        "4,5,6\n"
+      ;
+      unittest::WriteFile(path, csv);
+
+      rapidcsv::Document doc1(path, rapidcsv::LabelParams(-1, -1));
+      unittest::ExpectEqual(std::string, doc1.GetCell<std::string>(1, 1),
+                            "he said \"hello\"");
+
+      // Save and reload - data must survive round-trip
+      doc1.Save(path);
+      rapidcsv::Document doc2(path, rapidcsv::LabelParams(-1, -1));
+
+      unittest::ExpectEqual(size_t, doc2.GetRowCount(), size_t(3));
+      unittest::ExpectEqual(size_t, doc2.GetColumnCount(), size_t(3));
+      unittest::ExpectEqual(std::string, doc2.GetCell<std::string>(1, 1),
+                            "he said \"hello\"");
+
+      unittest::DeleteFile(path);
+    }
+
+    // Test 2: Cell containing only a quote character
+    {
+      std::string path = unittest::TempPath();
+
+      std::istringstream ss("a,b\nx,\"y\"\n");
+      rapidcsv::Document doc1(ss, rapidcsv::LabelParams(-1, -1));
+      doc1.SetCell<std::string>(1, 0, "\"");
+      doc1.Save(path);
+
+      rapidcsv::Document doc2(path, rapidcsv::LabelParams(-1, -1));
+      unittest::ExpectEqual(std::string, doc2.GetCell<std::string>(1, 0), "\"");
+
+      unittest::DeleteFile(path);
+    }
+
+    // Test 3: Empty quoted cells round-trip
+    {
+      std::string path = unittest::TempPath();
+      std::string csv = "\"\",\"\",\"\"\n";
+      unittest::WriteFile(path, csv);
+
+      rapidcsv::Document doc1(path, rapidcsv::LabelParams(-1, -1));
+      unittest::ExpectEqual(std::string, doc1.GetCell<std::string>(0, 0), "");
+      unittest::ExpectEqual(std::string, doc1.GetCell<std::string>(1, 0), "");
+      unittest::ExpectEqual(std::string, doc1.GetCell<std::string>(2, 0), "");
+
+      doc1.Save(path);
+      rapidcsv::Document doc2(path, rapidcsv::LabelParams(-1, -1));
+      unittest::ExpectEqual(size_t, doc2.GetColumnCount(), size_t(3));
+      unittest::ExpectEqual(std::string, doc2.GetCell<std::string>(0, 0), "");
+      unittest::ExpectEqual(std::string, doc2.GetCell<std::string>(1, 0), "");
+      unittest::ExpectEqual(std::string, doc2.GetCell<std::string>(2, 0), "");
+
+      unittest::DeleteFile(path);
+    }
+  }
+  catch (const std::exception& ex)
+  {
+    std::cout << ex.what() << std::endl;
+    rv = 1;
+  }
+
+  return rv;
+}


### PR DESCRIPTION
Fix https://github.com/d99kris/rapidcsv/issues/204:

WriteCsv auto-quote logic checks for separator, space and newline in cell content, but does not check for the quote character itself. This causes cells containing quotes (but no separator/space/newline) to be written unquoted and unescaped, producing malformed CSV output that corrupts data on re-read.

Add quote character to the auto-quote condition and add test104 to verify round-trip integrity for cells containing quote characters.