### PR TITLE
fixes silent integer truncation for narrow types in Converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if(RAPIDCSV_BUILD_TESTS)
   endif()
   add_unit_test(test102)
   add_unit_test(test103)
+  add_unit_test(test104)
 
   # perf tests
   add_perf_test(ptest001)

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -193,22 +193,42 @@ namespace rapidcsv
         }
         else if (typeid(T) == typeid(signed char))
         {
-          pVal = static_cast<T>(std::stoi(pStr));
+          const int i = std::stoi(pStr);
+          if ((i < std::numeric_limits<signed char>::min()) || (i > std::numeric_limits<signed char>::max()))
+          {
+            throw std::out_of_range("stoi: out of signed char range");
+          }
+          pVal = static_cast<T>(i);
           return;
         }
         else if (typeid(T) == typeid(unsigned char))
         {
-          pVal = static_cast<T>(std::stoi(pStr));
+          const int i = std::stoi(pStr);
+          if ((i < 0) || (i > std::numeric_limits<unsigned char>::max()))
+          {
+            throw std::out_of_range("stoi: out of unsigned char range");
+          }
+          pVal = static_cast<T>(i);
           return;
         }
         else if (typeid(T) == typeid(short))
         {
-          pVal = static_cast<T>(std::stoi(pStr));
+          const int i = std::stoi(pStr);
+          if ((i < std::numeric_limits<short>::min()) || (i > std::numeric_limits<short>::max()))
+          {
+            throw std::out_of_range("stoi: out of short range");
+          }
+          pVal = static_cast<T>(i);
           return;
         }
         else if (typeid(T) == typeid(unsigned short))
         {
-          pVal = static_cast<T>(std::stoi(pStr));
+          const int i = std::stoi(pStr);
+          if ((i < 0) || (i > std::numeric_limits<unsigned short>::max()))
+          {
+            throw std::out_of_range("stoi: out of unsigned short range");
+          }
+          pVal = static_cast<T>(i);
           return;
         }
         else if (typeid(T) == typeid(long))

--- a/tests/test104.cpp
+++ b/tests/test104.cpp
@@ -1,0 +1,58 @@
+// test104.cpp - narrow integer type range checking
+
+#include <rapidcsv.h>
+#include "unittest.h"
+
+int main()
+{
+  int rv = 0;
+
+  std::string csv =
+    "col\n"
+    "127\n"
+    "128\n"
+    "-128\n"
+    "-129\n"
+    "255\n"
+    "256\n"
+    "32767\n"
+    "32768\n"
+    "65535\n"
+    "65536\n"
+  ;
+
+  std::string path = unittest::TempPath();
+  unittest::WriteFile(path, csv);
+
+  try
+  {
+    rapidcsv::Document doc(path);
+
+    // signed char: valid range [-128, 127]
+    unittest::ExpectEqual(int, static_cast<int>(doc.GetCell<signed char>(0, 0)), 127);
+    ExpectException(doc.GetCell<signed char>(0, 1), std::out_of_range);
+    unittest::ExpectEqual(int, static_cast<int>(doc.GetCell<signed char>(0, 2)), -128);
+    ExpectException(doc.GetCell<signed char>(0, 3), std::out_of_range);
+
+    // unsigned char: valid range [0, 255]
+    unittest::ExpectEqual(int, static_cast<int>(doc.GetCell<unsigned char>(0, 4)), 255);
+    ExpectException(doc.GetCell<unsigned char>(0, 5), std::out_of_range);
+
+    // short: valid range [-32768, 32767]
+    unittest::ExpectEqual(int, static_cast<int>(doc.GetCell<short>(0, 6)), 32767);
+    ExpectException(doc.GetCell<short>(0, 7), std::out_of_range);
+
+    // unsigned short: valid range [0, 65535]
+    unittest::ExpectEqual(int, static_cast<int>(doc.GetCell<unsigned short>(0, 8)), 65535);
+    ExpectException(doc.GetCell<unsigned short>(0, 9), std::out_of_range);
+  }
+  catch (const std::exception& ex)
+  {
+    std::cout << ex.what() << std::endl;
+    rv = 1;
+  }
+
+  unittest::DeleteFile(path);
+
+  return rv;
+}


### PR DESCRIPTION
Fix https://github.com/d99kris/rapidcsv/issues/206:

When converting CSV cell values to signed char, unsigned char, short, or unsigned short, std::stoi returns an int which is then silently truncated via static_cast. For example, "256" read as unsigned char silently becomes 0, and "32768" read as short becomes -32768.

Add range checks against std::numeric_limits before the static_cast, throwing std::out_of_range when the value does not fit. Add test104 to verify range checking for all four narrow integer types.