### PR TITLE
fixes SetColumnName/SetRowName not removing old name from label map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ if(RAPIDCSV_BUILD_TESTS)
   endif()
   add_unit_test(test102)
   add_unit_test(test103)
+  add_unit_test(test104)
 
   # perf tests
   add_perf_test(ptest001)

--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1448,6 +1448,14 @@ namespace rapidcsv
       }
 
       const size_t dataColumnIdx = GetDataColumnIndex(pColumnIdx);
+
+      // remove old name from map before adding new one
+      const size_t nameRowIdx = static_cast<size_t>(mLabelParams.mColumnNameIdx);
+      if ((nameRowIdx < mData.size()) && (dataColumnIdx < mData.at(nameRowIdx).size()))
+      {
+        const std::string oldName = mData.at(nameRowIdx).at(dataColumnIdx);
+        mColumnNames.erase(oldName);
+      }
       mColumnNames[pColumnName] = dataColumnIdx;
 
       // increase table size if necessary:
@@ -1505,6 +1513,14 @@ namespace rapidcsv
     void SetRowName(size_t pRowIdx, const std::string& pRowName)
     {
       const size_t dataRowIdx = GetDataRowIndex(pRowIdx);
+
+      // remove old name from map before adding new one
+      if ((mLabelParams.mRowNameIdx >= 0) && (dataRowIdx < mData.size()) &&
+          (static_cast<size_t>(mLabelParams.mRowNameIdx) < mData.at(dataRowIdx).size()))
+      {
+        const std::string oldName = mData.at(dataRowIdx).at(static_cast<size_t>(mLabelParams.mRowNameIdx));
+        mRowNames.erase(oldName);
+      }
       mRowNames[pRowName] = dataRowIdx;
       if (mLabelParams.mRowNameIdx < 0)
       {

--- a/tests/test104.cpp
+++ b/tests/test104.cpp
@@ -1,0 +1,61 @@
+// test104.cpp - SetColumnName / SetRowName stale label cleanup
+
+#include <rapidcsv.h>
+#include "unittest.h"
+
+int main()
+{
+  int rv = 0;
+
+  std::string csv =
+    "name,value\n"
+    "row1,100\n"
+    "row2,200\n"
+  ;
+
+  std::string path = unittest::TempPath();
+  unittest::WriteFile(path, csv);
+
+  try
+  {
+    // Test 1: SetColumnName removes old name from map
+    {
+      rapidcsv::Document doc(path, rapidcsv::LabelParams(0, 0));
+
+      unittest::ExpectEqual(int, doc.GetColumnIdx("value"), 0);
+      doc.SetColumnName(0, "price");
+      unittest::ExpectEqual(int, doc.GetColumnIdx("price"), 0);
+      unittest::ExpectEqual(int, doc.GetColumnIdx("value"), -1);
+    }
+
+    // Test 2: SetRowName removes old name from map
+    {
+      rapidcsv::Document doc(path, rapidcsv::LabelParams(0, 0));
+
+      unittest::ExpectEqual(int, doc.GetRowIdx("row1"), 0);
+      doc.SetRowName(0, "item1");
+      unittest::ExpectEqual(int, doc.GetRowIdx("item1"), 0);
+      unittest::ExpectEqual(int, doc.GetRowIdx("row1"), -1);
+    }
+
+    // Test 3: Data access by new name works correctly
+    {
+      rapidcsv::Document doc(path, rapidcsv::LabelParams(0, 0));
+
+      doc.SetColumnName(0, "price");
+      unittest::ExpectEqual(std::string, doc.GetCell<std::string>("price", "row1"), "100");
+
+      doc.SetRowName(0, "item1");
+      unittest::ExpectEqual(std::string, doc.GetCell<std::string>("price", "item1"), "100");
+    }
+  }
+  catch (const std::exception& ex)
+  {
+    std::cout << ex.what() << std::endl;
+    rv = 1;
+  }
+
+  unittest::DeleteFile(path);
+
+  return rv;
+}


### PR DESCRIPTION
Fix https://github.com/d99kris/rapidcsv/issues/208:

SetColumnName and SetRowName add the new name to the internal label map but do not remove the old name. After renaming, the old name still resolves via GetColumnIdx/GetRowIdx, which can cause silent data misdirection when the old name is used after a rename. 
Remove the old name from the map before inserting the new one. Add test104 to verify old names are properly cleaned up.