### PR TITLE
fix GetColumnNames() undefined behavior on empty label row

### DIFF
--- a/src/rapidcsv.h
+++ b/src/rapidcsv.h
@@ -1473,9 +1473,13 @@ namespace rapidcsv
     {
       if (mLabelParams.mColumnNameIdx >= 0)
       {
-        return std::vector<std::string>(mData.at(static_cast<size_t>(mLabelParams.mColumnNameIdx)).begin() +
-                                        (mLabelParams.mRowNameIdx + 1),
-                                        mData.at(static_cast<size_t>(mLabelParams.mColumnNameIdx)).end());
+        const auto& labelRow = mData.at(static_cast<size_t>(mLabelParams.mColumnNameIdx));
+        const size_t offset = static_cast<size_t>(mLabelParams.mRowNameIdx + 1);
+        if (offset <= labelRow.size())
+        {
+          return std::vector<std::string>(labelRow.begin() + static_cast<int>(offset),
+                                          labelRow.end());
+        }
       }
 
       return std::vector<std::string>();


### PR DESCRIPTION
Fix https://github.com/d99kris/rapidcsv/issues/213:
GetColumnNames() did .begin() + (mRowNameIdx + 1) on the label row without checking that the row has enough elements. When the label row is empty (e.g. after InsertRow on an empty document with LabelParams(0,0)), .begin() wraps a null pointer and adding to it is undefined behavior.

Add a bounds check before the iterator arithmetic so it returns an empty vector instead of hitting UB.